### PR TITLE
Tweak fallthrough comments to get recognized by gcc7

### DIFF
--- a/src/idl_gen_general.cpp
+++ b/src/idl_gen_general.cpp
@@ -326,7 +326,7 @@ Type DestinationType(const Type &type, bool vectorelem) {
     case BASE_TYPE_VECTOR:
       if (vectorelem)
         return DestinationType(type.VectorType(), vectorelem);
-      // else fall thru:
+      // else fall thru
     default: return type;
   }
 }
@@ -372,7 +372,7 @@ std::string DestinationMask(const Type &type, bool vectorelem) {
     case BASE_TYPE_VECTOR:
       if (vectorelem)
         return DestinationMask(type.VectorType(), vectorelem);
-      // else fall thru:
+      // else fall thru
     default: return "";
   }
 }

--- a/src/reflection.cpp
+++ b/src/reflection.cpp
@@ -419,8 +419,8 @@ Offset<const Table *> CopyTable(FlatBufferBuilder &fbb,
               offset = fbb.CreateVector(elements).o;
               break;
             }
-            // FALL-THRU:
           }
+          // FALL-THRU
           default: {  // Scalars and structs.
             auto element_size = GetTypeSize(element_base_type);
             if (elemobjectdef && elemobjectdef->is_struct())
@@ -457,8 +457,8 @@ Offset<const Table *> CopyTable(FlatBufferBuilder &fbb,
                      subobjectdef.bytesize());
           break;
         }
-        // else: FALL-THRU:
       }
+      // ELSE FALL-THRU
       case reflection::Union:
       case reflection::String:
       case reflection::Vector:


### PR DESCRIPTION
Hi @ceejatec, I'm trying to make build working on Fedora 26, where gcc7 is default compiler. To do so, this patch have to be backported from flatbuffers 1.7.0.

Shall it be separate branch?

I'm also going to upload  change for tlm about adding `fedora26` as a platform, as RocksDB from CentOS 7 does not work there, and it feels like it make sense to rebuild all dependencies for Fedora natively.